### PR TITLE
add -v flag to CLI options to download video; add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ cython_debug/
 
 # project-specific files
 /audio
+/video
 
 # Editor / IDE
 *.swp

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ class TestMain:
         with patch.object(sys, "argv", ["yt_downloader", "-s", "  https://youtube.com/watch?v=1  "]):
             with patch("yt_downloader.cli.config") as mock_config:
                 cli.main()
-        mock_process_single.assert_called_once_with("  https://youtube.com/watch?v=1  ")
+        mock_process_single.assert_called_once_with("  https://youtube.com/watch?v=1  ", video=False)
 
     @patch("yt_downloader.cli._log_completion")
     @patch("yt_downloader.cli.process_single_url")
@@ -46,7 +46,7 @@ class TestMain:
             with patch("yt_downloader.cli.config") as mock_config:
                 mock_config.YT_URLS_FILE = "/path/to/urls.txt"
                 cli.main()
-        mock_process_multiple.assert_called_once_with("/path/to/urls.txt")
+        mock_process_multiple.assert_called_once_with("/path/to/urls.txt", video=False)
         mock_log_completion.assert_called_once_with(single=False)
 
 
@@ -57,7 +57,7 @@ class TestProcessSingleUrl:
         mock_process_url: MagicMock,
     ) -> None:
         cli.process_single_url("  https://youtube.com/watch?v=1  ")
-        mock_process_url.assert_called_once_with("https://youtube.com/watch?v=1")
+        mock_process_url.assert_called_once_with("https://youtube.com/watch?v=1", video=False)
 
     @patch("yt_downloader.cli.core.process_url")
     def test_process_single_url_catches_invalid_url_error_and_logs(
@@ -91,8 +91,8 @@ class TestProcessMultipleUrls:
         url_file.write_text("https://youtube.com/watch?v=1\nhttps://youtube.com/watch?v=2\n", encoding="utf-8")
         cli.process_multiple_urls(str(url_file))
         assert mock_process_single.call_count == 2
-        mock_process_single.assert_any_call("https://youtube.com/watch?v=1")
-        mock_process_single.assert_any_call("https://youtube.com/watch?v=2")
+        mock_process_single.assert_any_call("https://youtube.com/watch?v=1", video=False)
+        mock_process_single.assert_any_call("https://youtube.com/watch?v=2", video=False)
 
     def test_process_multiple_urls_missing_file_logs_error(
         self,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -65,7 +65,64 @@ class TestDownloadHighestBitrateVideo:
             core.download_highest_bitrate_video(mock_yt)
 
 
-class TestCreateMp3File:
+class TestResolutionHeight:
+    def test_resolution_height_720p(self) -> None:
+        mock_stream = MagicMock()
+        mock_stream.resolution = "720p"
+        assert core._resolution_height(mock_stream) == 720
+
+    def test_resolution_height_360p(self) -> None:
+        mock_stream = MagicMock()
+        mock_stream.resolution = "360p"
+        assert core._resolution_height(mock_stream) == 360
+
+    def test_resolution_height_empty_returns_zero(self) -> None:
+        mock_stream = MagicMock()
+        mock_stream.resolution = ""
+        assert core._resolution_height(mock_stream) == 0
+
+    def test_resolution_height_missing_returns_zero(self) -> None:
+        mock_stream = MagicMock(spec=[])  # no resolution attr
+        assert core._resolution_height(mock_stream) == 0
+
+
+class TestDownloadVideoMp4:
+    @patch("yt_downloader.core.utils.get_formatted_title")
+    @patch("yt_downloader.core.os.mkdir")
+    @patch("yt_downloader.core.os.path.exists")
+    def test_download_video_mp4_success(
+        self,
+        mock_exists: MagicMock,
+        mock_mkdir: MagicMock,
+        mock_get_formatted_title: MagicMock,
+    ) -> None:
+        mock_exists.return_value = False
+        mock_get_formatted_title.return_value = "My_Video"
+        mock_stream = MagicMock()
+        mock_stream.resolution = "720p"
+        mock_stream.download.return_value = "/video/My_Video.mp4"
+        mock_streams = MagicMock()
+        mock_streams.filter.return_value = [mock_stream]
+        mock_yt = MagicMock()
+        mock_yt.streams = mock_streams
+        mock_yt.title = "My Video"
+        with patch("yt_downloader.core.config") as mock_config:
+            mock_config.VIDEO_DIR = "/video"
+            result = core.download_video_mp4(mock_yt)
+        mock_mkdir.assert_called_once()
+        mock_get_formatted_title.assert_called_once_with("My Video")
+        mock_stream.download.assert_called_once_with(
+            output_path="/video", filename="My_Video.mp4"
+        )
+        assert result == "/video/My_Video.mp4"
+
+    def test_download_video_mp4_no_progressive_streams(self) -> None:
+        mock_streams = MagicMock()
+        mock_streams.filter.return_value = []
+        mock_yt = MagicMock()
+        mock_yt.streams = mock_streams
+        with pytest.raises(DownloadError, match="No progressive video streams found"):
+            core.download_video_mp4(mock_yt)
     @patch("yt_downloader.core.utils.remove_video_file")
     @patch("yt_downloader.core.write_audio_file_from_video")
     @patch("yt_downloader.core.os.path.exists")
@@ -135,6 +192,45 @@ class TestProcessUrl:
         mock_download.return_value = "/tmp/temp_video.mp4"
         core.process_url(valid_youtube_url)
         mock_create_yt.assert_called_once_with(valid_youtube_url)
+        mock_download.assert_called_once_with(mock_yt)
+        mock_create_mp3.assert_called_once_with("/tmp/temp_video.mp4", "My Video")
+
+    @patch("yt_downloader.core.download_video_mp4")
+    @patch("yt_downloader.core.create_mp3_file")
+    @patch("yt_downloader.core.download_highest_bitrate_video")
+    @patch("yt_downloader.core.create_youtube_object")
+    def test_process_url_video_true_calls_download_video_mp4_only(
+        self,
+        mock_create_yt: MagicMock,
+        mock_download_audio: MagicMock,
+        mock_create_mp3: MagicMock,
+        mock_download_video: MagicMock,
+        valid_youtube_url: str,
+    ) -> None:
+        mock_yt = MagicMock()
+        mock_yt.title = "My Video"
+        mock_create_yt.return_value = mock_yt
+        core.process_url(valid_youtube_url, video=True)
+        mock_create_yt.assert_called_once_with(valid_youtube_url)
+        mock_download_video.assert_called_once_with(mock_yt)
+        mock_download_audio.assert_not_called()
+        mock_create_mp3.assert_not_called()
+
+    @patch("yt_downloader.core.create_mp3_file")
+    @patch("yt_downloader.core.download_highest_bitrate_video")
+    @patch("yt_downloader.core.create_youtube_object")
+    def test_process_url_video_false_uses_audio_path(
+        self,
+        mock_create_yt: MagicMock,
+        mock_download: MagicMock,
+        mock_create_mp3: MagicMock,
+        valid_youtube_url: str,
+    ) -> None:
+        mock_yt = MagicMock()
+        mock_yt.title = "My Video"
+        mock_create_yt.return_value = mock_yt
+        mock_download.return_value = "/tmp/temp_video.mp4"
+        core.process_url(valid_youtube_url, video=False)
         mock_download.assert_called_once_with(mock_yt)
         mock_create_mp3.assert_called_once_with("/tmp/temp_video.mp4", "My Video")
 

--- a/yt_downloader/cli.py
+++ b/yt_downloader/cli.py
@@ -13,13 +13,14 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-s", "--single", help="Set download mode to single. Requires YouTube video link as an argument in quotation marks.")
-    group.add_argument("-m", "--multiple", help="Set download mode to multiple. Reads YouTube video links from youtube_urls.txt.", action="store_true")
+    group.add_argument("-m", "--multiple", action="store_true", help="Set download mode to multiple. Reads YouTube video links from youtube_urls.txt.")
+    parser.add_argument("-v", "--video", action="store_true", help="Download as MP4 video instead of MP3.")
     args = parser.parse_args()
     if args.single:
-        process_single_url(args.single)
+        process_single_url(args.single, video=args.video)
         _log_completion(single=True)
     elif args.multiple:
-        process_multiple_urls(config.YT_URLS_FILE)
+        process_multiple_urls(config.YT_URLS_FILE, video=args.video)
         _log_completion(single=False)
     else:
         parser.print_help()
@@ -32,19 +33,19 @@ def _log_completion(*, single: bool) -> None:
         logging.info("All processes finished.")
 
 
-def process_single_url(url: str) -> None:
+def process_single_url(url: str, *, video: bool = False) -> None:
     try:
-        core.process_url(url.strip())
+        core.process_url(url.strip(), video=video)
     except exceptions.YtDownloaderError as e:
         logging.error(e)
 
 
-def process_multiple_urls(file_path: str) -> None:
+def process_multiple_urls(file_path: str, *, video: bool = False) -> None:
     try:
         with open(file_path, encoding="utf-8") as file:
             for url in file:
                 url = url.strip()
                 if url:
-                    process_single_url(url)
+                    process_single_url(url, video=video)
     except FileNotFoundError:
         logging.error("URLs file not found: %s", file_path)

--- a/yt_downloader/config.py
+++ b/yt_downloader/config.py
@@ -2,5 +2,6 @@ import os
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 AUDIO_DIR = os.path.join(PROJECT_ROOT, "audio")
+VIDEO_DIR = os.path.join(PROJECT_ROOT, "video")
 YT_URLS_FILE = os.path.join(PROJECT_ROOT, "youtube_urls.txt")
 TITLE_MAX_LENGTH = 60

--- a/yt_downloader/core.py
+++ b/yt_downloader/core.py
@@ -9,10 +9,13 @@ from yt_downloader.exceptions import InvalidURLError, DownloadError
 # For testing assert correct exception rise and are catched and for correct inputs assert nothing goes wrong
 # Everything needs mocking except validate_url in unit tests
 
-def process_url(url: str) -> None:
+def process_url(url: str, *, video: bool = False) -> None:
     yt = create_youtube_object(url)
     if yt is None:
         raise DownloadError("Invalid or unavailable video")
+    if video:
+        download_video_mp4(yt)
+        return
     video_file = download_highest_bitrate_video(yt)
     if video_file is None:
         raise DownloadError("Could not find video to process")
@@ -40,6 +43,26 @@ def download_highest_bitrate_video(yt_object: YouTube, temp_file: str = 'temp_vi
     if not stream:
         raise DownloadError("No streams found for video.")
     return stream.download(filename=temp_file)
+
+def _resolution_height(stream) -> int:
+    """Parse resolution string (e.g. '720p') to height in pixels for sorting."""
+    res = getattr(stream, "resolution", None) or ""
+    if not res or not res.endswith("p"):
+        return 0
+    try:
+        return int(res[:-1])
+    except ValueError:
+        return 0
+
+def download_video_mp4(yt_object: YouTube) -> str:
+    progressive_streams = yt_object.streams.filter(progressive=True)
+    if not progressive_streams:
+        raise DownloadError("No progressive video streams found.")
+    stream = max(progressive_streams, key=_resolution_height)
+    if not os.path.exists(config.VIDEO_DIR):
+        os.mkdir(config.VIDEO_DIR)
+    filename = utils.get_formatted_title(yt_object.title) + ".mp4"
+    return stream.download(output_path=config.VIDEO_DIR, filename=filename)
 
 def create_mp3_file(video_file: str, title: str) -> None:
     try:


### PR DESCRIPTION
Added CLI flags `-v` and `--video` to download 720p YouTube videos. Covered new functionality with tests. Closes #3 